### PR TITLE
Introduce DevToolsController for chrome workspaces

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -34,6 +34,7 @@ module Rails
   eager_autoload do
     autoload :HealthController
     autoload :PwaController
+    autoload :DevtoolsController
   end
 
   class << self

--- a/railties/lib/rails/devtools_controller.rb
+++ b/railties/lib/rails/devtools_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Rails::DevtoolsController < ActionController::Base # :nodoc:
+  def show
+    require "digest"
+    root_path = Rails.root.to_s
+    hash = Digest::SHA1.hexdigest(root_path)
+    uuid = "#{hash[0..7]}-#{hash[8..11]}-#{hash[12..15]}-#{hash[16..19]}-#{hash[20..31]}"
+
+    render json: {
+      "workspace": {
+        "root": root_path,
+        "uuid": uuid
+      }
+    }
+  end
+end

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  # get ".well-known/appspecific/com.chrome.devtools.json", to: "rails/devtools#show"
 
   <%- end -%>
   # Defines the root path route ("/")

--- a/railties/test/rails_devtools_controller_test.rb
+++ b/railties/test/rails_devtools_controller_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class DevtoolsControllerTest < ActionController::TestCase
+  tests Rails::DevtoolsController
+
+  def setup
+    Rails.application.routes.draw do
+      get ".well-known/appspecific/com.chrome.devtools.json" => "rails/devtools#show"
+    end
+    @routes = Rails.application.routes
+  end
+
+  test "devtools controller renders JSON with workspace root and uuid" do
+    get :show
+    assert_response :success
+    assert_match(/application\/json/, @response.content_type)
+
+    json_response = JSON.parse(@response.body)
+    assert json_response.key?("workspace")
+    assert json_response["workspace"].key?("root")
+    assert json_response["workspace"].key?("uuid")
+    assert_equal Rails.root.to_s, json_response["workspace"]["root"]
+  end
+end


### PR DESCRIPTION
### Motivation / Background

[Chromium is able to automatically detect workspace folders](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md). In order to do that, performs a call to `.well-known/appspecific/com.chrome.devtools.json`.

This PR introduces a default controller to respond to this call.

### Detail

A Rails::DevtoolsController is provided by the Rails engine and a path is added (commented out) to the routes.rb file:

```ruby
get ".well-known/appspecific/com.chrome.devtools.json", to: "rails/devtools#show"
```

The controller returns the `Rails.root` path and a uuid that changes only if the Rails.root path changes.

### Additional information

There's plenty of other ways we can implement this:
* a middleware
* a non-modifiable route
* clone the controller in the project

I think this implementation is a good trade-off: it provides a good default, which can be easily enabled/disabled also in new apps. It can be easily overridden if the functionality changes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
